### PR TITLE
Resolve rpath

### DIFF
--- a/ruby/ext/ruby_ndtypes/extconf.rb
+++ b/ruby/ext/ruby_ndtypes/extconf.rb
@@ -17,10 +17,10 @@ Dir.chdir(File.join(File.dirname(__FILE__) + "/ndtypes")) do
   if unix?
     ["libndtypes", "libndtypes/compat", "libndtypes/serialize"].each do |f|
       Dir.chdir(f) do
-        Dir.mkdir(".objs") unless Dir.exists? ".objs"  
+        Dir.mkdir(".objs") unless Dir.exists? ".objs"
       end
     end
-    
+
     system("./configure --prefix=#{File.expand_path("../")} --with-docs=no")
     system("make")
     system("make install")
@@ -35,6 +35,7 @@ $INSTALLFILES = [
 binaries = File.expand_path(File.join(File.dirname(__FILE__) + "/lib/"))
 headers = File.expand_path(File.join(File.dirname(__FILE__) + "/include/"))
 $LOAD_PATH << File.expand_path(binaries)
+append_ldflags("-Wl,-rpath #{binaries}")
 
 ["ndtypes"].each do |lib|
   find_library(lib, nil, binaries)


### PR DESCRIPTION
This pull-request fixes the following load error occurred on macOS.

```
[1] pry(main)> require 'ndtypes'
LoadError: dlopen(/Users/mrkn/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/ndtypes-0.2.0dev4/lib/ruby_ndtypes/ruby_ndtypes.bundle, 9): Library not loaded: @rpath/libndtypes.0.dylib
  Referenced from: /Users/mrkn/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/ndtypes-0.2.0dev4/lib/ruby_ndtypes/ruby_ndtypes.bundle
  Reason: image not found - /Users/mrkn/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/ndtypes-0.2.0dev4/lib/ruby_ndtypes/ruby_ndtypes.bundle
from /Users/mrkn/.rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
```

Note that I tested this only on macOS High Sierra.